### PR TITLE
Support for Multiple Fallback Proxies

### DIFF
--- a/README.md
+++ b/README.md
@@ -38,7 +38,7 @@ go install github.com/dadav/gorge@latest
 
 ```bash
 Run this command to start serving your own puppet modules.
-You can also enable a fallback proxy to forward the requests to
+You can also enable one or more fallback proxies to forward the requests to
 when you don't have the requested module in your local module
 set yet.
 
@@ -80,7 +80,7 @@ gorge serve
 # use fallback forge and cache request of modules and files
 gorge serve --fallback-proxy https://forge.puppetlabs.com --cache-prefixes /v3/files,/v3/modules
 
-# use internal forge server and fallback forge and cache request of modules and files
+# first use the internal forge server, then (if failed) the official forge and cache request of modules and files
 gorge serve --fallback-proxy https://internal-forge.example.com,https://forge.puppetlabs.com --cache-prefixes /v3/files,/v3/modules
 ```
 

--- a/README.md
+++ b/README.md
@@ -55,7 +55,7 @@ Flags:
       --cache-prefixes string     url prefixes to cache (default "/v3/files")
       --cors string               allowed cors origins separated by comma (default "*")
       --dev                       enables dev mode
-      --fallback-proxy string     optional fallback upstream proxy url
+      --fallback-proxy string     optional comma separated list of fallback upstream proxy urls
   -h, --help                      help for serve
       --import-proxied-releases   add every proxied modules to local store
       --jwt-secret string         jwt secret (default "changeme")
@@ -79,6 +79,9 @@ gorge serve
 
 # use fallback forge and cache request of modules and files
 gorge serve --fallback-proxy https://forge.puppetlabs.com --cache-prefixes /v3/files,/v3/modules
+
+# use internal forge server and fallback forge and cache request of modules and files
+gorge serve --fallback-proxy https://internal-forge.example.com,https://forge.puppetlabs.com --cache-prefixes /v3/files,/v3/modules
 ```
 
 ## 🍰 Configuration
@@ -105,7 +108,7 @@ cache-prefixes: /v3/files
 cors: "*"
 # Enables the dev mode.
 dev: false
-# Upstream forge to use when local requests return 404
+# List of comma separated upstream forge(s) to use when local requests return 404
 fallback-proxy:
 # Import proxied modules into local backend.
 import-proxied-releases: false

--- a/cmd/serve.go
+++ b/cmd/serve.go
@@ -49,7 +49,7 @@ var serveCmd = &cobra.Command{
 	Use:   "serve",
 	Short: "Start the puppet forge webserver",
 	Long: `Run this command to start serving your own puppet modules.
-You can also enable a fallback proxy to forward the requests to
+You can also enable fallback proxies to forward the requests to
 when you don't have the requested module in your local module
 set yet.
 
@@ -245,7 +245,7 @@ func init() {
 	serveCmd.Flags().IntVar(&config.ModulesScanSec, "modules-scan-sec", 0, "seconds between scans of directory containing all the modules. (default 0 means only scan at startup)")
 	serveCmd.Flags().StringVar(&config.Backend, "backend", "filesystem", "backend to use")
 	serveCmd.Flags().StringVar(&config.CORSOrigins, "cors", "*", "allowed cors origins separated by comma")
-	serveCmd.Flags().StringVar(&config.FallbackProxyUrl, "fallback-proxy", "", "optional fallback upstream proxy url")
+	serveCmd.Flags().StringVar(&config.FallbackProxyUrl, "fallback-proxy", "", "optional comma separated list of fallback upstream proxy urls")
 	serveCmd.Flags().BoolVar(&config.Dev, "dev", false, "enables dev mode")
 	serveCmd.Flags().StringVar(&config.CachePrefixes, "cache-prefixes", "/v3/files", "url prefixes to cache")
 	serveCmd.Flags().StringVar(&config.JwtSecret, "jwt-secret", "changeme", "jwt secret")

--- a/cmd/serve.go
+++ b/cmd/serve.go
@@ -138,7 +138,7 @@ You can also enable the caching functionality to speed things up.`,
 					r.Use(cachedMiddleware)
 				}
 
-				r.Use(customMiddleware.ProxyFallback(config.FallbackProxyUrl, func(status int) bool {
+				r.Use(customMiddleware.ProxyFallback(strings.Split(config.FallbackProxyUrl, ","), func(status int) bool {
 					return status == http.StatusNotFound
 				},
 					func(r *http.Response) {

--- a/internal/v3/api/module.go
+++ b/internal/v3/api/module.go
@@ -9,7 +9,6 @@ import (
 	"strconv"
 	"strings"
 
-	"github.com/dadav/gorge/internal/log"
 	"github.com/dadav/gorge/internal/v3/backend"
 	"github.com/dadav/gorge/internal/v3/utils"
 	gen "github.com/dadav/gorge/pkg/gen/v3/openapi"
@@ -92,7 +91,6 @@ type GetModule500Response struct {
 func (s *ModuleOperationsApi) GetModule(ctx context.Context, moduleSlug string, withHtml bool, includeFields []string, excludeFields []string, ifModifiedSince string) (gen.ImplResponse, error) {
 	module, err := backend.ConfiguredBackend.GetModuleBySlug(moduleSlug)
 	if err != nil {
-		log.Log.Error(err)
 		return gen.Response(
 			http.StatusNotFound,
 			GetModule404Response{


### PR DESCRIPTION
Hi @dadav 

We create a number of internal puppet modules and serve them up in an internal forge server

We would like our `gorge` servers to be able to check the internal forge for a module and then go out to a fallback proxy if the internal forge returns a 404. For example:
```
gorge serve --fallback-proxy https://internal-forge.example.com,https://forge.puppetlabs.com
```

I have provided a first cut PR for this proposal but I am not sure I am implementing it in the correct location. Experiments show:
* module on internal forge - everything works well, and external forge is not checked

```
## Internal Forge
[root@sypls059 jwarburt]# ./gorge serve --dev --bind 0.0.0.0 --port 6666 --cachedir /var/tmp/gorge-internal/cache --modulesdir /var/tmp/gorge-internal/modules
2024-06-24T11:44:43.900+1000    INFO    cmd/serve.go:169        Listen on 0.0.0.0:6666
2024-06-24T11:44:43.900+1000    DEBUG   backend/filesystem.go:331       Reading /var/tmp/gorge-internal/modules/atsonkov-grubby/atsonkov-grubby-0.3.2.tar.gz

### Gorge Proxy with internal forge an dpuppet forge as fallback proxies
root@0b9a4634d8af:/usr/src/myapp# go install -buildvcs=false .
root@0b9a4634d8af:/usr/src/myapp# rm -rf /var/tmp/gorge/modules/* /var/tmp/gorge/cache/*; gorge serve --dev --bind 0.0.0.0 --cachedir /var/tmp/gorge/cache --modulesdir /var/tmp/gorge/modules --import-proxied-releases --cache-prefi
xes /v3/files,/v3/modules --fallback-proxy http://sypls059:6666,https://forge.puppetlabs.com
2024-06-24T01:51:25.167Z        INFO    cmd/serve.go:169        Listen on 0.0.0.0:8080
```

Client
```
[root@sypls062 puppet-forge]# grep -v '#' /export/home/jwarburt/puppet-forge/r10k.yaml
---
cachedir: '/var/cache/r10k'
pool_size: 30
forge:
  baseurl: 'http://sypls059:7777'
[root@sypls062 puppet-forge]# grep -v '#' /export/home/jwarburt/puppet-forge/Puppetfile
mod 'atsonkov-grubby', '0.3.2'

[root@sypls062 puppet-forge]# /opt/puppetlabs/puppet/bin/r10k --config=/export/home/jwarburt/puppet-forge/r10k.yaml puppetfile install --force --puppetfile /export/home/jwarburt/puppet-forge/Puppetfile --moduledir /export/home/jwarburt/puppet-forge/work-area/$(uuidgen)

[root@sypls062 puppet-forge]# ls -lart work-area/908a4935-0434-42bc-a533-ed669d2c018c/
total 48
drwxr-xr-x 27 jwarburt jwarburt 36864 Jun 24 12:13 ..
drwxr-xr-x 12 root     root      4096 Jun 24 12:13 grubby
drwxr-xr-x  3 root     root      4096 Jun 24 12:13 .
```
And the server
```
2024/06/24 02:13:06 "GET http://sypls059:7777/v3/modules/atsonkov-grubby HTTP/1.1" from 10.70.71.28:58104 - 404 63B in 213.663µs
2024-06-24T02:13:06.568Z        INFO    middleware/proxy.go:41  Forwarding request to [http://sypls059:6666 https://forge.puppetlabs.com]

2024-06-24T02:13:06.568Z        DEBUG   middleware/proxy.go:57  loop 0

2024-06-24T02:13:06.569Z        DEBUG   middleware/proxy.go:106 Response of proxied request to http://sypls059:6666 is 200

2024-06-24T02:13:06.569Z        DEBUG   middleware/proxy.go:109 Found module upstream from http://sypls059:6666

```

When the module is not available on the internal forge, it looks like it is retried correctly from the puppet forge, but returns an error to `r10k`

All configuration is the same as above.

Client
```
[root@sypls062 puppet-forge]# grep -v '#' /export/home/jwarburt/puppet-forge/Puppetfile
mod 'puppet-letsencrypt', '8.0.2'
[root@sypls062 puppet-forge]# grep -v '#' /export/home/jwarburt/puppet-forge/r10k.yaml
---
cachedir: '/var/cache/r10k'
pool_size: 30
forge:
  baseurl: 'http://sypls059:7777'
[root@sypls062 puppet-forge]#
[root@sypls062 puppet-forge]# /opt/puppetlabs/puppet/bin/r10k --config=/export/home/jwarburt/puppet-forge/r10k.yaml puppetfile install --force --puppetfile /export/home/jwarburt/puppet-forge/Puppetfile --moduledir /export/home/jwarburt/puppet-forge/work-area/$(uuidgen)
ERROR    -> Module letsencrypt failed to synchronize due to Unable to connect to http://sypls059 (for request /v3/modules/puppet-letsencrypt): end of file reached
ERROR    -> Error during concurrent deploy of a module: Unable to connect to http://sypls059 (for request /v3/modules/puppet-letsencrypt): end of file reached
ERROR    -> Unable to connect to http://sypls059 (for request /v3/modules/puppet-letsencrypt): end of file reached
```

Server
```
2024/06/24 02:17:47 "GET http://sypls059:7777/v3/modules/puppet-letsencrypt HTTP/1.1" from 10.70.71.28:61050 - 404 63B in 169.017µs
2024-06-24T02:17:47.667Z        INFO    middleware/proxy.go:41  Forwarding request to [http://sypls059:6666 https://forge.puppetlabs.com]

2024-06-24T02:17:47.667Z        DEBUG   middleware/proxy.go:57  loop 0

2024-06-24T02:17:47.668Z        DEBUG   middleware/proxy.go:106 Response of proxied request to http://sypls059:6666 is 404

2024-06-24T02:17:47.668Z        DEBUG   middleware/proxy.go:57  loop 1

2024-06-24T02:17:47.712Z        DEBUG   middleware/proxy.go:106 Response of proxied request to https://forge.puppetlabs.com is 200

2024-06-24T02:17:47.713Z        DEBUG   middleware/proxy.go:109 Found module upstream from https://forge.puppetlabs.com
```

Any pointers in the right direction would be appreciated

thanks
John