### PR TITLE
Improve cache and fallback-proxy behaviour for /v3/release

### DIFF
--- a/README.md
+++ b/README.md
@@ -90,6 +90,7 @@ Flags:
       --bind string               host to listen to (default "127.0.0.1")
       --cache-max-age int         max number of seconds responses should be cached (default 86400)
       --cache-prefixes string     url prefixes to cache (default "/v3/files")
+      --cache-by-full-request-uri will cache responses by the full request URI (incl. query fragments) instead of only the request path
       --cors string               allowed cors origins separated by comma (default "*")
       --dev                       enables dev mode
       --drop-privileges           drops privileges to the given user/group
@@ -207,6 +208,7 @@ GORGE_BACKEND=filesystem
 GORGE_BIND=127.0.0.1
 GORGE_CACHE_MAX_AGE=86400
 GORGE_CACHE_PREFIXES=/v3/files
+GORGE_CACHE_BY_FULL_REQUEST_URI=false
 GORGE_CORS="*"
 GORGE_DEV=false
 GORGE_DROP_PRIVILEGES=false

--- a/cmd/serve.go
+++ b/cmd/serve.go
@@ -142,7 +142,13 @@ You can also enable the caching functionality to speed things up.`,
 			if !config.NoCache {
 				customKeyFunc := func(r *http.Request) uint64 {
 					token := r.Header.Get("Authorization")
-					return stampede.StringToHash(r.Method, strings.ToLower(token))
+					requestURI := r.URL.Path
+
+					if config.CacheByFullRequestURI {
+						requestURI = r.URL.RequestURI()
+					}
+
+					return stampede.StringToHash(r.Method, requestURI, strings.ToLower(token))
 				}
 
 				cachedMiddleware := stampede.HandlerWithKey(512, time.Duration(config.CacheMaxAge)*time.Second, customKeyFunc, strings.Split(config.CachePrefixes, ",")...)
@@ -341,6 +347,7 @@ func init() {
 	serveCmd.Flags().Int64Var(&config.CacheMaxAge, "cache-max-age", 86400, "max number of seconds responses should be cached")
 	serveCmd.Flags().BoolVar(&config.NoCache, "no-cache", false, "disables the caching functionality")
 	serveCmd.Flags().BoolVar(&config.ImportProxiedReleases, "import-proxied-releases", false, "add every proxied modules to local store")
+	serveCmd.Flags().BoolVar(&config.CacheByFullRequestURI, "cache-by-full-request-uri", false, "will cache responses by the full request URI (incl. query fragments) instead of only the request path")
 }
 
 func checkModules(sleepSeconds int) {

--- a/internal/config/config.go
+++ b/internal/config/config.go
@@ -16,6 +16,7 @@ var (
 	FallbackProxyUrl      string
 	NoCache               bool
 	CachePrefixes         string
+	CacheByFullRequestURI bool
 	CacheMaxAge           int64
 	ImportProxiedReleases bool
 	JwtSecret             string

--- a/internal/v3/api/release.go
+++ b/internal/v3/api/release.go
@@ -282,14 +282,9 @@ func (s *ReleaseOperationsApi) GetReleases(ctx context.Context, limit int32, off
 		}
 	}
 
-	prefiltered := []*gen.Release{}
-	if len(allReleases) > int(offset) {
-		prefiltered = allReleases[offset:]
-	}
-
 	if filterSet {
 		// We search through all available releases to see if they match the filter
-		for _, r := range prefiltered {
+		for _, r := range allReleases {
 			if module != "" && r.Module.Slug != module {
 				continue
 			}
@@ -301,17 +296,19 @@ func (s *ReleaseOperationsApi) GetReleases(ctx context.Context, limit int32, off
 			filtered = append(filtered, r)
 		}
 	} else {
-		filtered = prefiltered
+		filtered = allReleases
 	}
 
-	i := 1
-	for _, release := range filtered {
-		if i > int(limit) {
-			break
-		}
+	if len(filtered) > int(offset) {
+		i := 1
+		for _, release := range filtered[offset:] {
+			if i > int(limit) {
+				break
+			}
 
-		results = append(results, *release)
-		i++
+			results = append(results, *release)
+			i++
+		}
 	}
 
 	// If we're using a fallback-proxy, we should return a 404 so the proxy can handle the request

--- a/internal/v3/api/release.go
+++ b/internal/v3/api/release.go
@@ -266,19 +266,15 @@ func (s *ReleaseOperationsApi) GetReleases(ctx context.Context, limit int32, off
 	if filterSet {
 		// We search through all available releases to see if they match the filter
 		for _, r := range prefiltered {
-			filterMatched := true
-
 			if module != "" && r.Module.Slug != module {
-				filterMatched = false
+				continue
 			}
 
 			if owner != "" && r.Module.Owner.Slug != owner {
-				filterMatched = false
+				continue
 			}
 
-			if filterMatched {
-				filtered = append(filtered, r)
-			}
+			filtered = append(filtered, r)
 		}
 	} else {
 		filtered = prefiltered

--- a/internal/v3/api/release.go
+++ b/internal/v3/api/release.go
@@ -266,14 +266,14 @@ func (s *ReleaseOperationsApi) GetReleases(ctx context.Context, limit int32, off
 	if filterSet {
 		// We search through all available releases to see if they match the filter
 		for _, r := range prefiltered {
-			var filterMatched bool
+			filterMatched := true
 
-			if module != "" && r.Module.Slug == module {
-				filterMatched = r.Module.Slug == module
+			if module != "" && r.Module.Slug != module {
+				filterMatched = false
 			}
 
-			if owner != "" && r.Module.Owner.Slug == owner {
-				filterMatched = r.Module.Owner.Slug == owner
+			if owner != "" && r.Module.Owner.Slug != owner {
+				filterMatched = false
 			}
 
 			if filterMatched {

--- a/internal/v3/ui/components/statistics.templ
+++ b/internal/v3/ui/components/statistics.templ
@@ -10,6 +10,7 @@ templ StatisticsView(stats *customMiddleware.Statistics) {
 	<div>
 		<h3>Statistics</h3>
 		<p>ActiveConnections: { strconv.Itoa(stats.ActiveConnections) }</p>
+		<p>ProxiedConnections: { strconv.Itoa(stats.ProxiedConnections) }</p>
 		<p>TotalConnections: { strconv.Itoa(stats.TotalConnections) }</p>
 		<p>TotalResponseTime: { stats.TotalResponseTime.String() }</p>
 		<table>
@@ -17,6 +18,7 @@ templ StatisticsView(stats *customMiddleware.Statistics) {
 				<tr>
 					<th>Path</th>
 					<th>Connections</th>
+					<th>Proxied Connections</th>
 					<th>Average ResponseTime</th>
 					<th>Total ResponseTime</th>
 				</tr>
@@ -26,6 +28,7 @@ templ StatisticsView(stats *customMiddleware.Statistics) {
 					<tr>
 						<td>{ path }</td>
 						<td>{ strconv.Itoa(connections) }</td>
+						<td>{ strconv.Itoa(stats.ProxiedConnectionsPerEndpoint[path]) }</td>
 						<td>{ (stats.ResponseTimePerEndpoint[path] / time.Duration(connections)).String() }</td>
 						<td>{ stats.ResponseTimePerEndpoint[path].String() }</td>
 					</tr>

--- a/internal/v3/ui/components/statistics_templ.go
+++ b/internal/v3/ui/components/statistics_templ.go
@@ -45,16 +45,29 @@ func StatisticsView(stats *customMiddleware.Statistics) templ.Component {
 		if templ_7745c5c3_Err != nil {
 			return templ_7745c5c3_Err
 		}
-		_, templ_7745c5c3_Err = templ_7745c5c3_Buffer.WriteString("</p><p>TotalConnections: ")
+		_, templ_7745c5c3_Err = templ_7745c5c3_Buffer.WriteString("</p><p>ProxiedConnections: ")
 		if templ_7745c5c3_Err != nil {
 			return templ_7745c5c3_Err
 		}
 		var templ_7745c5c3_Var3 string
-		templ_7745c5c3_Var3, templ_7745c5c3_Err = templ.JoinStringErrs(strconv.Itoa(stats.TotalConnections))
+		templ_7745c5c3_Var3, templ_7745c5c3_Err = templ.JoinStringErrs(strconv.Itoa(stats.ProxiedConnections))
 		if templ_7745c5c3_Err != nil {
-			return templ.Error{Err: templ_7745c5c3_Err, FileName: `internal/v3/ui/components/statistics.templ`, Line: 13, Col: 61}
+			return templ.Error{Err: templ_7745c5c3_Err, FileName: `internal/v3/ui/components/statistics.templ`, Line: 13, Col: 65}
 		}
 		_, templ_7745c5c3_Err = templ_7745c5c3_Buffer.WriteString(templ.EscapeString(templ_7745c5c3_Var3))
+		if templ_7745c5c3_Err != nil {
+			return templ_7745c5c3_Err
+		}
+		_, templ_7745c5c3_Err = templ_7745c5c3_Buffer.WriteString("</p><p>TotalConnections: ")
+		if templ_7745c5c3_Err != nil {
+			return templ_7745c5c3_Err
+		}
+		var templ_7745c5c3_Var4 string
+		templ_7745c5c3_Var4, templ_7745c5c3_Err = templ.JoinStringErrs(strconv.Itoa(stats.TotalConnections))
+		if templ_7745c5c3_Err != nil {
+			return templ.Error{Err: templ_7745c5c3_Err, FileName: `internal/v3/ui/components/statistics.templ`, Line: 14, Col: 61}
+		}
+		_, templ_7745c5c3_Err = templ_7745c5c3_Buffer.WriteString(templ.EscapeString(templ_7745c5c3_Var4))
 		if templ_7745c5c3_Err != nil {
 			return templ_7745c5c3_Err
 		}
@@ -62,16 +75,16 @@ func StatisticsView(stats *customMiddleware.Statistics) templ.Component {
 		if templ_7745c5c3_Err != nil {
 			return templ_7745c5c3_Err
 		}
-		var templ_7745c5c3_Var4 string
-		templ_7745c5c3_Var4, templ_7745c5c3_Err = templ.JoinStringErrs(stats.TotalResponseTime.String())
+		var templ_7745c5c3_Var5 string
+		templ_7745c5c3_Var5, templ_7745c5c3_Err = templ.JoinStringErrs(stats.TotalResponseTime.String())
 		if templ_7745c5c3_Err != nil {
-			return templ.Error{Err: templ_7745c5c3_Err, FileName: `internal/v3/ui/components/statistics.templ`, Line: 14, Col: 58}
+			return templ.Error{Err: templ_7745c5c3_Err, FileName: `internal/v3/ui/components/statistics.templ`, Line: 15, Col: 58}
 		}
-		_, templ_7745c5c3_Err = templ_7745c5c3_Buffer.WriteString(templ.EscapeString(templ_7745c5c3_Var4))
+		_, templ_7745c5c3_Err = templ_7745c5c3_Buffer.WriteString(templ.EscapeString(templ_7745c5c3_Var5))
 		if templ_7745c5c3_Err != nil {
 			return templ_7745c5c3_Err
 		}
-		_, templ_7745c5c3_Err = templ_7745c5c3_Buffer.WriteString("</p><table><thead><tr><th>Path</th><th>Connections</th><th>Average ResponseTime</th><th>Total ResponseTime</th></tr></thead> <tbody>")
+		_, templ_7745c5c3_Err = templ_7745c5c3_Buffer.WriteString("</p><table><thead><tr><th>Path</th><th>Connections</th><th>Proxied Connections</th><th>Average ResponseTime</th><th>Total ResponseTime</th></tr></thead> <tbody>")
 		if templ_7745c5c3_Err != nil {
 			return templ_7745c5c3_Err
 		}
@@ -80,23 +93,10 @@ func StatisticsView(stats *customMiddleware.Statistics) templ.Component {
 			if templ_7745c5c3_Err != nil {
 				return templ_7745c5c3_Err
 			}
-			var templ_7745c5c3_Var5 string
-			templ_7745c5c3_Var5, templ_7745c5c3_Err = templ.JoinStringErrs(path)
-			if templ_7745c5c3_Err != nil {
-				return templ.Error{Err: templ_7745c5c3_Err, FileName: `internal/v3/ui/components/statistics.templ`, Line: 27, Col: 16}
-			}
-			_, templ_7745c5c3_Err = templ_7745c5c3_Buffer.WriteString(templ.EscapeString(templ_7745c5c3_Var5))
-			if templ_7745c5c3_Err != nil {
-				return templ_7745c5c3_Err
-			}
-			_, templ_7745c5c3_Err = templ_7745c5c3_Buffer.WriteString("</td><td>")
-			if templ_7745c5c3_Err != nil {
-				return templ_7745c5c3_Err
-			}
 			var templ_7745c5c3_Var6 string
-			templ_7745c5c3_Var6, templ_7745c5c3_Err = templ.JoinStringErrs(strconv.Itoa(connections))
+			templ_7745c5c3_Var6, templ_7745c5c3_Err = templ.JoinStringErrs(path)
 			if templ_7745c5c3_Err != nil {
-				return templ.Error{Err: templ_7745c5c3_Err, FileName: `internal/v3/ui/components/statistics.templ`, Line: 28, Col: 37}
+				return templ.Error{Err: templ_7745c5c3_Err, FileName: `internal/v3/ui/components/statistics.templ`, Line: 29, Col: 16}
 			}
 			_, templ_7745c5c3_Err = templ_7745c5c3_Buffer.WriteString(templ.EscapeString(templ_7745c5c3_Var6))
 			if templ_7745c5c3_Err != nil {
@@ -107,9 +107,9 @@ func StatisticsView(stats *customMiddleware.Statistics) templ.Component {
 				return templ_7745c5c3_Err
 			}
 			var templ_7745c5c3_Var7 string
-			templ_7745c5c3_Var7, templ_7745c5c3_Err = templ.JoinStringErrs((stats.ResponseTimePerEndpoint[path] / time.Duration(connections)).String())
+			templ_7745c5c3_Var7, templ_7745c5c3_Err = templ.JoinStringErrs(strconv.Itoa(connections))
 			if templ_7745c5c3_Err != nil {
-				return templ.Error{Err: templ_7745c5c3_Err, FileName: `internal/v3/ui/components/statistics.templ`, Line: 29, Col: 87}
+				return templ.Error{Err: templ_7745c5c3_Err, FileName: `internal/v3/ui/components/statistics.templ`, Line: 30, Col: 37}
 			}
 			_, templ_7745c5c3_Err = templ_7745c5c3_Buffer.WriteString(templ.EscapeString(templ_7745c5c3_Var7))
 			if templ_7745c5c3_Err != nil {
@@ -120,11 +120,37 @@ func StatisticsView(stats *customMiddleware.Statistics) templ.Component {
 				return templ_7745c5c3_Err
 			}
 			var templ_7745c5c3_Var8 string
-			templ_7745c5c3_Var8, templ_7745c5c3_Err = templ.JoinStringErrs(stats.ResponseTimePerEndpoint[path].String())
+			templ_7745c5c3_Var8, templ_7745c5c3_Err = templ.JoinStringErrs(strconv.Itoa(stats.ProxiedConnectionsPerEndpoint[path]))
 			if templ_7745c5c3_Err != nil {
-				return templ.Error{Err: templ_7745c5c3_Err, FileName: `internal/v3/ui/components/statistics.templ`, Line: 30, Col: 56}
+				return templ.Error{Err: templ_7745c5c3_Err, FileName: `internal/v3/ui/components/statistics.templ`, Line: 31, Col: 67}
 			}
 			_, templ_7745c5c3_Err = templ_7745c5c3_Buffer.WriteString(templ.EscapeString(templ_7745c5c3_Var8))
+			if templ_7745c5c3_Err != nil {
+				return templ_7745c5c3_Err
+			}
+			_, templ_7745c5c3_Err = templ_7745c5c3_Buffer.WriteString("</td><td>")
+			if templ_7745c5c3_Err != nil {
+				return templ_7745c5c3_Err
+			}
+			var templ_7745c5c3_Var9 string
+			templ_7745c5c3_Var9, templ_7745c5c3_Err = templ.JoinStringErrs((stats.ResponseTimePerEndpoint[path] / time.Duration(connections)).String())
+			if templ_7745c5c3_Err != nil {
+				return templ.Error{Err: templ_7745c5c3_Err, FileName: `internal/v3/ui/components/statistics.templ`, Line: 32, Col: 87}
+			}
+			_, templ_7745c5c3_Err = templ_7745c5c3_Buffer.WriteString(templ.EscapeString(templ_7745c5c3_Var9))
+			if templ_7745c5c3_Err != nil {
+				return templ_7745c5c3_Err
+			}
+			_, templ_7745c5c3_Err = templ_7745c5c3_Buffer.WriteString("</td><td>")
+			if templ_7745c5c3_Err != nil {
+				return templ_7745c5c3_Err
+			}
+			var templ_7745c5c3_Var10 string
+			templ_7745c5c3_Var10, templ_7745c5c3_Err = templ.JoinStringErrs(stats.ResponseTimePerEndpoint[path].String())
+			if templ_7745c5c3_Err != nil {
+				return templ.Error{Err: templ_7745c5c3_Err, FileName: `internal/v3/ui/components/statistics.templ`, Line: 33, Col: 56}
+			}
+			_, templ_7745c5c3_Err = templ_7745c5c3_Buffer.WriteString(templ.EscapeString(templ_7745c5c3_Var10))
 			if templ_7745c5c3_Err != nil {
 				return templ_7745c5c3_Err
 			}


### PR DESCRIPTION
Use case; caching with fallback to puppet forge.

- stampede cache-key now takes request path and/or *full* request URI into account (incl query parameters)
  Note: query parameters is semi-important to cache responses for /v3/releases queries as done by `puppet module install`. 
  Before this patch, with caching enabled, you could see puppetlabs-stdlib responses when requesting `/v3/releases?module=puppetlabs-logrotate` if puppetlabs-stdlib was the first to be queried.

- show basic "proxied requests" stats in the UI

- if fallback-proxy is enabled, and `/v3/releases` is requested, requests are now redirected to the proxy sooner to be more consistent in responses returned and prevent empty responses.