### PR TITLE
Fix code scanning alert no. 11: Uncontrolled data used in path expression

### DIFF
--- a/internal/v3/backend/filesystem.go
+++ b/internal/v3/backend/filesystem.go
@@ -161,6 +161,11 @@ func (s *FilesystemBackend) AddRelease(releaseData []byte) (*gen.Release, error)
 		return nil, err
 	}
 
+	// Validate metadata.Name to ensure it does not contain path separators or parent directory references
+	if strings.Contains(metadata.Name, "/") || strings.Contains(metadata.Name, "\\") || strings.Contains(metadata.Name, "..") {
+		return nil, errors.New("invalid module name")
+	}
+
 	releaseSlug := fmt.Sprintf("%s-%s", metadata.Name, metadata.Version)
 	if !utils.CheckReleaseSlug(releaseSlug) {
 		return nil, errors.New("invalid release slug")


### PR DESCRIPTION
Fixes [https://github.com/dadav/gorge/security/code-scanning/11](https://github.com/dadav/gorge/security/code-scanning/11)

To fix the problem, we need to ensure that the user input used to construct file paths is properly validated and sanitized. Specifically, we should:
1. Ensure that `metadata.Name` does not contain any path separators or parent directory references.
2. Ensure that the constructed file path is within the intended directory.

We will add validation checks to ensure that `metadata.Name` is a valid single path component and does not contain any path traversal characters.


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
